### PR TITLE
In PROD, GBLOCKs is throwing a report error

### DIFF
--- a/lib/kb_gblocks/kb_gblocksImpl.py
+++ b/lib/kb_gblocks/kb_gblocksImpl.py
@@ -843,7 +843,7 @@ class kb_gblocks:
                 #'message': '',
                 'message': clw_buf_str,
                 'direct_html': '',
-                'direct_html_index': None,
+                #'direct_html_index': None,
                 'file_links': [],
                 'html_links': [],
                 'workspace_name': params['workspace_name'],


### PR DESCRIPTION
The report error is due to an unknown field 'direct_html_index'. Commented it out.

This is important because it affects one of the narratives that were added to the KBase Orgs.
@sychan @scanon @dcchivian 